### PR TITLE
Fix 'Uncaught TypeError' by using jQuery instead of $.

### DIFF
--- a/fullcalendar.viewmore.js
+++ b/fullcalendar.viewmore.js
@@ -285,4 +285,4 @@
     return calInstance.fullCalendar('getView').cellDate(cellPos);
   }
   
-}).call($.fn.limitEvents.constructor.prototype, jQuery);
+}).call(jQuery.fn.limitEvents.constructor.prototype, jQuery);

--- a/fullcalendar.viewmore.js
+++ b/fullcalendar.viewmore.js
@@ -70,9 +70,9 @@
     });
   };
   
-  this.increaseHeight = function(height, windowResized){
+  this.increaseHeight = function(height, windowResized, td){
     var cal = this.calendar,
-          cells =  cal.find('.fc-view-month tbody tr td'),
+          cells = td || cal.find('.fc-view-month tbody tr td'),
           fcDayContent = cells.find('.fc-day-content'),
           cellHeight, fcDayContentHeight;
           
@@ -125,6 +125,7 @@
                             
                             return false;
                         });
+                        self.increaseHeight(25, false, td);
                     }
                     if ($.isFunction(_eventRender)) _eventRender(event, element);
                     return false; //prevents event from being rendered


### PR DESCRIPTION
I get the following errors:
`Uncaught TypeError: Cannot read property 'fn' of undefined; line 288
Uncaught TypeError: Object [object Object] has no method 'observers'; line 45`

Switching from `$` to `jQuery` in the `.call()` fixes it.
